### PR TITLE
add Travis conf to use latest version of aiohttp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,13 @@ install:
   - python setup.py develop
 
 script:
-  python setup.py test
+  # asyncio git repo has only *.pyx files, so install cython too.
+  - '[ -z "$LATEST_ASYNCIO" ] || pip install -U cython git+https://github.com/KeepSafe/aiohttp.git'
+  - python setup.py test
 
 env:
   matrix:
     # PYTHONASYNCIODEBUG environment variable is considered as enabled if it
     # is any non empty string.
-    - PYTHONASYNCIODEBUG=X
-    - PYTHONASYNCIODEBUG=
+    - PYTHONASYNCIODEBUG=X LATEST_ASYNCIO=
+    - PYTHONASYNCIODEBUG=  LATEST_ASYNCIO=X

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
   - pip install --upgrade pip setuptools wheel
   - pip install -Ur requirements-dev.txt
   - python setup.py develop
-  # asyncio git repo has only *.pyx files, so install cython too.
+  # aiohttp git repo has only *.pyx files, so install cython too.
   - '[ -z "$LATEST_ASYNCIO" ] || pip install -U cython git+https://github.com/KeepSafe/aiohttp.git'
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,10 @@ install:
   - pip install --upgrade pip setuptools wheel
   - pip install -Ur requirements-dev.txt
   - python setup.py develop
-
-script:
   # asyncio git repo has only *.pyx files, so install cython too.
   - '[ -z "$LATEST_ASYNCIO" ] || pip install -U cython git+https://github.com/KeepSafe/aiohttp.git'
+
+script:
   - python setup.py test
 
 env:


### PR DESCRIPTION
I see that router is being refactored in aiohttp, and aiohttp_cors uses some router implementation details, so let's test against master version of aiohttp too.
