### PR TITLE
fix aiohttp_cors to work with aiohttp==0.21

### DIFF
--- a/aiohttp_cors/cors_config.py
+++ b/aiohttp_cors/cors_config.py
@@ -164,11 +164,16 @@ class CorsConfig:
         :return: ``route``.
         """
 
-        if _AIOHTTP_0_21 and isinstance(route, web.AbstractResource):
-            # TODO: Resources should be supported.
-            raise RuntimeError(
-                "You need to pass Route to the CORS config, and you passed "
-                "Resource.")
+        if _AIOHTTP_0_21:
+            # TODO: Use web.AbstractResource when this issue will be fixed:
+            # <https://github.com/KeepSafe/aiohttp/pull/767>
+            from aiohttp.web_urldispatcher import AbstractResource
+
+            if isinstance(route, AbstractResource):
+                # TODO: Resources should be supported.
+                raise RuntimeError(
+                    "You need to pass Route to the CORS config, and you "
+                    "passed Resource.")
 
         if route in self._preflight_route_settings:
             _logger.warning(

--- a/aiohttp_cors/cors_config.py
+++ b/aiohttp_cors/cors_config.py
@@ -17,8 +17,10 @@
 
 import asyncio
 import collections
+from pkg_resources import parse_version
 from typing import Mapping, Union, Any
 
+import aiohttp
 from aiohttp import hdrs, web
 
 from .urldispatcher_router_adapter import UrlDispatcherRouterAdapter
@@ -43,6 +45,8 @@ _SIMPLE_RESPONSE_HEADERS = frozenset([
     hdrs.LAST_MODIFIED,
     hdrs.PRAGMA
 ])
+
+_AIOHTTP_0_21 = parse_version(aiohttp.__version__) >= parse_version('0.21.0')
 
 
 def _parse_config_options(
@@ -159,6 +163,12 @@ class CorsConfig:
             CORS options for the route.
         :return: ``route``.
         """
+
+        if _AIOHTTP_0_21 and isinstance(route, web.AbstractResource):
+            # TODO: Resources should be supported.
+            raise RuntimeError(
+                "You need to pass Route to the CORS config, and you passed "
+                "Resource.")
 
         if route in self._preflight_route_settings:
             _logger.warning(
@@ -286,6 +296,21 @@ class CorsConfig:
         # pylint: disable=bad-builtin
         return frozenset(filter(None, headers))
 
+    def _preflight_routes(self, path):
+        """Get list of registered preflight routes that handles path"""
+        if _AIOHTTP_0_21:
+            # TODO: Using of private _match(), because there is no public,
+            # see <https://github.com/KeepSafe/aiohttp/issues/766>.
+            routes = [
+                route for route in self._preflight_route_settings.keys() if
+                route.resource._match(path) is not None]
+        else:
+            routes = [
+                route for route in self._preflight_route_settings.keys() if
+                route.match(path) is not None]
+
+        return routes
+
     @asyncio.coroutine
     def _preflight_handler(self, request: web.Request):
         """CORS preflight request handler"""
@@ -301,9 +326,7 @@ class CorsConfig:
 
         # TODO: Test difference between request.raw_path and request.path.
         path = request.raw_path
-        preflight_routes = [
-            route for route in self._preflight_route_settings.keys() if
-            route.match(path) is not None]
+        preflight_routes = self._preflight_routes(path)
         method_to_config = {}
         for route in preflight_routes:
             config, methods = self._preflight_route_settings[route]

--- a/aiohttp_cors/urldispatcher_router_adapter.py
+++ b/aiohttp_cors/urldispatcher_router_adapter.py
@@ -16,7 +16,9 @@
 """
 
 import re
+from pkg_resources import parse_version
 
+import aiohttp
 from aiohttp import web
 
 from .abc import AbstractRouterAdapter
@@ -24,7 +26,11 @@ from .abc import AbstractRouterAdapter
 __all__ = ("UrlDispatcherRouterAdapter",)
 
 
-class UrlDispatcherRouterAdapter(AbstractRouterAdapter):
+_AIOHTTP_0_21 = parse_version(aiohttp.__version__) >= parse_version('0.21.0')
+
+
+# Router adapter for aiohttp < 0.21.0
+class _UrlDispatcherRouterAdapter_v20(AbstractRouterAdapter):
     """Router adapter for aiohttp.web.UrlDispatcher"""
     def __init__(self, router: web.UrlDispatcher):
         self._router = router
@@ -56,3 +62,53 @@ class UrlDispatcherRouterAdapter(AbstractRouterAdapter):
             raise RuntimeError("Unhandled route type", route)
 
         return new_route
+
+
+# Router adapter for aiohttp >= 0.21.0
+class _UrlDispatcherRouterAdapter_v21(AbstractRouterAdapter):
+    """Router adapter for aiohttp.web.UrlDispatcher"""
+    def __init__(self, router: web.UrlDispatcher):
+        self._router = router
+
+    def route_methods(self, route: web.AbstractRoute):
+        """Returns list of HTTP methods that route handles"""
+        return [route.method]
+
+    def add_options_method_handler(self, route: web.AbstractRoute, handler):
+        method = "OPTIONS"
+
+        if isinstance(route, web.ResourceRoute):
+            # Route added through Resource API.
+            new_route = route.resource.add_route(method, handler)
+
+        elif isinstance(route, web.StaticRoute):
+            # Route added through add_static() - not handled as ResourceRoute
+            # in aiohttp 0.21.0.
+
+            # TODO: Use custom matches that uses `str.startswith()` if
+            # regexp performance is not enough.
+            pattern = re.compile("^" + re.escape(route._prefix))
+            new_route = web.DynamicRoute(
+                method, handler, None, pattern, "")
+            self._router.register_route(new_route)
+
+        elif isinstance(route, web.PlainRoute):
+            # May occur only if user manually creates PlainRoute.
+            new_route = self._router.add_route(method, route._path, handler)
+
+        elif isinstance(route, web.DynamicRoute):
+            # May occur only if user manually creates DynamicRoute.
+            new_route = web.DynamicRoute(
+                method, handler, None, route._pattern, route._formatter)
+            self._router.register_route(new_route)
+
+        else:
+            raise RuntimeError("Unhandled route type", route)
+
+        return new_route
+
+
+if _AIOHTTP_0_21:
+    UrlDispatcherRouterAdapter = _UrlDispatcherRouterAdapter_v21
+else:
+    UrlDispatcherRouterAdapter = _UrlDispatcherRouterAdapter_v20

--- a/aiohttp_cors/urldispatcher_router_adapter.py
+++ b/aiohttp_cors/urldispatcher_router_adapter.py
@@ -70,14 +70,18 @@ class _UrlDispatcherRouterAdapter_v21(AbstractRouterAdapter):
     def __init__(self, router: web.UrlDispatcher):
         self._router = router
 
-    def route_methods(self, route: web.AbstractRoute):
+    def route_methods(self, route):
         """Returns list of HTTP methods that route handles"""
         return [route.method]
 
-    def add_options_method_handler(self, route: web.AbstractRoute, handler):
+    def add_options_method_handler(self, route, handler):
         method = "OPTIONS"
 
-        if isinstance(route, web.ResourceRoute):
+        # TODO: Use web.ResourceRoute when this issue will be fixed:
+        # <https://github.com/KeepSafe/aiohttp/pull/767>
+        from aiohttp.web_urldispatcher import ResourceRoute
+
+        if isinstance(route, ResourceRoute):
             # Route added through Resource API.
             new_route = route.resource.add_route(method, handler)
 

--- a/tests/integration/test_real_browser.py
+++ b/tests/integration/test_real_browser.py
@@ -173,7 +173,12 @@ class IntegrationServers:
         # Add CORS routes.
         for server_name in cors_server_names:
             server_descr = self.servers[server_name]
-            server_descr.cors.add(server_descr.app.router["cors_resource"])
+            # TODO: Starting from aiohttp 0.21.0 name-based access returns
+            # Resource, not Route. Manually get route while aiohttp_cors
+            # doesn't support configuring for Resources.
+            resource = server_descr.app.router["cors_resource"]
+            route = next(iter(resource))
+            server_descr.cors.add(route)
 
     @asyncio.coroutine
     def stop_servers(self):


### PR DESCRIPTION
This commit adds workaround for missing "match()" method, see <https://github.com/KeepSafe/aiohttp/issues/766>.

Adds support in RouterAdapter for Resource-based routes.

However configuring CORS for Resources is not yet supported.

This change will make pre-0.21 Route-based user code to work with aiohttp 0.21, if user doesn't used name-based lookup of routes (which is one of backward incompatible changes in 0.21).